### PR TITLE
typo: prey / pray

### DIFF
--- a/src/epub/text/act-4.xhtml
+++ b/src/epub/text/act-4.xhtml
@@ -1354,7 +1354,7 @@
 									<br/>
 									<span>To have him suddenly convey’d away.</span>
 									<br/>
-									<span>Cancel his bond of life, dear God, I prey,</span>
+									<span>Cancel his bond of life, dear God, I pray,</span>
 									<br/>
 									<span>That I may live to say, The dog is dead!</span>
 								</p>


### PR DESCRIPTION
[Folger Shakespeare Library](https://www.folger.edu/explore/shakespeares-works/richard-iii/read/4/4/) has `pray` which is what I assume it should be, and edited it to be here.

[Open Source Shakespeare](https://www.opensourceshakespeare.org/views/plays/play_view.php?WorkID=richard3&Scope=entire&pleasewait=1&msg=pl#a4,s4) has the same typo as here, but I could not find where it's source material is from after cursory investigation.